### PR TITLE
pass aws token through to knox, but don't require it.  also, upgrade ver...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -311,6 +311,7 @@ S3.prototype.startWriting = function(callback) {
         key: this.data.awsKey,
         secret: this.data.awsSecret,
         bucket: this.uri.hostname.split('.')[0],
+        token: this.data.awsToken,
         secure: false
     });
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tilelive-s3",
     "version": "0.4.0",
     "dependencies": {
-        "knox": "0.4.x",
+        "knox": "0.5.x",
         "tilejson": "~0.3.2"
     },
     "devDependencies": {


### PR DESCRIPTION
...sion of knox to latest, which supports passing through an undefined aws token (ie, it won't set an undefined token anymore if token passed through to knox is not defined
