### PR TITLE
Fix socket hangups

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -239,6 +239,7 @@ S3.prototype.putTile = function(z, x, y, data, callback) {
             req.emit('error', err);
         });
         req.on('response', function(res) {
+            res.on('error', cb);
             if (res.statusCode === 200) {
                 stats.put++;
                 stats.txout += data.length;


### PR DESCRIPTION
This pull appears to fix the uncaught socket hangups we were seeing with this project. It's still unclear if adding `res.on('error', fn)` fixed it or changing `once()` to `on()` for existing listeners fixed it (or both). Finding out would require more intensive testing.
