### PR TITLE
Tell npm 1.2.24 to install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     },
     "main": "./lib/index.js",
     "scripts": {
-        "test": "mocha -R spec"
+        "test": "mocha -R spec",
+        "install": "node-waf configure build"
     },
     "engines": {
         "node": ">= 0.4 && < 0.9.0"


### PR DESCRIPTION
It looks like npm 1.2.24 (bundled with node 0.8.24) doesn't run wscripts by default.

I tested this against node 0.8.22 and node 0.8.24, and `npm install` is happy on both, and `npm test` was too.
