### PR TITLE
http.getAgent removed after node v0.4.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ function S3(uri, callback) {
         if (source && source.data) ['tiles', 'grids'].forEach(function(key) {
             if (!source.data[key] || !source.data[key].length) return;
             var hostname = url.parse(source.data[key][0]).hostname;
-            var agent = http.globalAgent || http.getAgent(hostname, '80');
+            var agent = http.globalAgent;
             agent.maxSockets = source.data.maxSockets || 128;
             // Set source bucket.
             if (hostname) source.bucket = source.bucket || hostname.split('.')[0];


### PR DESCRIPTION
Fixes #16

http.globalAgent will never be false [based on this](https://github.com/joyent/node/blob/v0.10.26/lib/http.js#L1341-L1342).
