### PR TITLE
Use tiletype to detect PBF format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -238,20 +238,19 @@ S3.prototype.putTile = function(z, x, y, data, callback) {
     }
     var key = this._prepareURL(this.putPath, z, x, y);
 
-    var headers = {};
+    var datatype = tiletype.type(data);
+    var headers = tiletype.headers(datatype) || {};
     headers['x-amz-acl'] = 'public-read';
     headers['Connection'] = 'keep-alive';
 
-    if (this.data.format === 'pbf') {
-        zlib.deflate(data, function(err, data) {
+    if (datatype === 'pbf') {
+        zlib.gzip(data, function(err, data) {
             if (err) return callback(err);
-            headers['Content-Type'] = 'application/x-protobuf';
             headers['Content-Length'] = data.length;
-            headers['Content-Encoding'] = 'deflate';
+            headers['Content-Encoding'] = 'gzip';
             s3.put(key, data, headers, callback);
         });
     } else {
-        headers['Content-Type'] = tiletype.contentType(data);
         headers['Content-Length'] = data.length;
         s3.put(key, data, headers, callback);
     }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "node-pre-gyp": "0.5.x",
     "knox": "0.8.x",
-    "tiletype": "git+https://github.com/mapbox/tiletype.git#content-encoding",
-    "tilejson": "git+https://github.com/mapbox/node-tilejson.git#content-encoding"
+    "tiletype": "git+https://github.com/mapbox/tiletype.git#content-encoding-evil",
+    "tilejson": "git+https://github.com/mapbox/node-tilejson.git#content-encoding-evil"
   },
   "devDependencies": {
     "mocha": "*"

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -128,10 +128,16 @@ describe('putTile', function() {
         var png = fs.readFileSync(fixtures + '/tile.png');
         s3.putTile(3, 6, 5, png, function(err) {
             assert.ifError(err);
-            s3.getTile(3, 6, 5, function(err, data, headers) {
-                assert.deepEqual(data, png);
-                assert.equal(headers['Content-Type'], 'image/png');
-                done();
+            s3.client.headFile('/tilelive-s3/test/3/6/5.png', function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.headers['content-type'], 'image/png');
+                assert.equal(res.headers['content-length'], '827');
+                assert.equal(res.headers['content-encoding'], undefined);
+                s3.getTile(3, 6, 5, function(err, data, headers) {
+                    assert.deepEqual(data, png);
+                    assert.equal(headers['Content-Type'], 'image/png');
+                    done();
+                });
             });
         });
     });
@@ -140,10 +146,17 @@ describe('putTile', function() {
         var pbf = fs.readFileSync(fixtures + '/tile.pbf');
         vt.putTile(3, 6, 5, pbf, function(err) {
             assert.ifError(err);
-            vt.getTile(3, 6, 5, function(err, data, headers) {
-                assert.deepEqual(data, pbf);
-                assert.equal(headers['Content-Type'], 'application/x-protobuf');
-                done();
+            vt.client.headFile('/tilelive-s3/vector/3/6/5.vector.pbf', function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.headers['content-type'], 'application/x-protobuf');
+                assert.equal(res.headers['content-length'], '40106');
+                assert.equal(res.headers['content-encoding'], 'gzip');
+                vt.getTile(3, 6, 5, function(err, data, headers) {
+                    assert.deepEqual(data, pbf);
+                    assert.equal(headers['Content-Type'], 'application/x-protobuf');
+                    assert.equal(headers['Content-Encoding'], undefined);
+                    done();
+                });
             });
         });
     });


### PR DESCRIPTION
- Removes trust of tilejson metadata to determine PBF format from https://github.com/mapbox/tilelive-s3/pull/21.
- Switches to gzip for compression of pbf vector tiles.
