### PR TITLE
Move stat reporting, dryrun options to env vars and add tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -241,7 +241,6 @@ S3.prototype.put = function(key, data, headers, callback) {
     var s3 = this;
     var client = this.client;
     var stats = this._stats;
-    var dryrun = this.data.dryrun;
     var complete = false;
 
     get();
@@ -278,7 +277,7 @@ S3.prototype.put = function(key, data, headers, callback) {
         });
     };
     function put() {
-        if (dryrun) {
+        if (process.env.TILELIVE_S3_DRYRUN) {
             stats.put++;
             stats.txout += data.length;
             return callback();
@@ -313,11 +312,13 @@ S3.prototype.getInfo = function(callback) {
 
     var data = {};
     for (var key in this.data) switch (key) {
-    case 'awsKey':
-    case 'awsSecret':
+    // These keys are actually used.
     case 'notFound':
     case 'maskLevel':
     case 'maskSolid':
+    // These keys are removed for legacy compatibility.
+    case 'awsKey':
+    case 'awsSecret':
     case 'maxSockets':
     case 'reportStats':
     case 'retry':
@@ -363,12 +364,12 @@ S3.prototype.startWriting = function(callback) {
 
 // Leave write mode.
 S3.prototype.stopWriting = function(callback) {
-    if (!this.data.reportStats) return callback && callback();
+    if (!process.env.TILELIVE_S3_STATS) return callback && callback();
 
     // @TODO let tilelive or tilemill expect a stats object
     // and process output instead.
     console.log('\n');
-    if (this.data.dryrun) {
+    if (process.env.TILELIVE_S3_DRYRUN) {
         console.log('Dryrun (no PUTs)');
         console.log('----------------');
     } else {


### PR DESCRIPTION
No more stuffing these options into data. Breaking API change, will start a 1.2.x series.

cc @rclark @willwhite 
