### PR TITLE
No-op on getGeocoderData when geocoder_data key is not set.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -415,6 +415,7 @@ function prepareURI(uri, id) {
 // Implements carmen#getGeocoderData method.
 S3.prototype.getGeocoderData = function(type, shard, callback) {
     if (!this.data) return callback(new Error('Tilesource not loaded'));
+    if (!this.data.geocoder_data) return callback();
 
     var extname = type === 'feature' ? '.json' : '.pbf';
     var source = this;

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -426,6 +426,7 @@ var expected = {
     search: 'Canada, CA'
 };
 
+var nogeocoder = new S3({data:JSON.parse(fs.readFileSync(__dirname + '/fixtures/vector.s3'))}, function() {});
 var from = new S3({data:JSON.parse(fs.readFileSync(__dirname + '/fixtures/geocoder.s3'))}, function() {});
 var prefixed = new S3({data:JSON.parse(fs.readFileSync(__dirname + '/fixtures/geocoder.prefixed.s3'))}, function() {});
 
@@ -441,6 +442,14 @@ tape('getGeocoderData (prefixed source)', function(assert) {
     prefixed.getGeocoderData('term', 0, function(err, buffer) {
         assert.ifError(err);
         assert.equal(3891, buffer.length);
+        assert.end();
+    });
+});
+
+tape('getGeocoderData (no geocoder)', function(assert) {
+    nogeocoder.getGeocoderData('term', 0, function(err, buffer) {
+        assert.ifError(err);
+        assert.equal(buffer, undefined);
         assert.end();
     });
 });


### PR DESCRIPTION
Makes it easier for carmen to skip over troublesome sources.
