### PR TITLE
Upgrade and bundle node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "aws-sdk": "~2.0.17",
     "knox": "0.8.x",
     "locking": "^2.0.0",
-    "node-pre-gyp": "~0.6.4",
+    "node-pre-gyp": "~0.6.7",
     "tilejson": "0.12.x",
     "tiletype": "0.1.x"
   },

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
     "aws-sdk": "~2.0.17",
     "knox": "0.8.x",
     "locking": "^2.0.0",
-    "node-pre-gyp": "0.5.x",
+    "node-pre-gyp": "~0.6.4",
     "tilejson": "0.12.x",
     "tiletype": "0.1.x"
   },
+  "bundledDependencies": [
+      "node-pre-gyp"
+  ],
   "devDependencies": {
     "tape": "3.0.x",
     "hat": "0.0.3"


### PR DESCRIPTION
node-pre-gyp needs to be bundled to be sure it is installed before the module need it to build itself. Not sure how we've been getting away without this, but either way the proper fix is to bundle.