### PR TITLE
New agentkeepalive

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "knox": "0.8.x",
     "locking": "^2.0.0",
     "node-pre-gyp": "~0.6.7",
-    "tilejson": "https://github.com/mapbox/node-tilejson/tarball/bump-agentkeepalive",
+    "tilejson": "0.13.x",
     "tiletype": "0.1.x"
   },
   "bundledDependencies": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "knox": "0.8.x",
     "locking": "^2.0.0",
     "node-pre-gyp": "~0.6.7",
-    "tilejson": "0.12.x",
+    "tilejson": "https://github.com/mapbox/node-tilejson/tarball/bump-agentkeepalive",
     "tiletype": "0.1.x"
   },
   "bundledDependencies": [


### PR DESCRIPTION
Bump tilejson dependency. Here we [reuse the agent](https://github.com/mapbox/tilelive-s3/blob/6d1d30193e8cb01e46bd78fec1da7dc90c0f79d8/lib/index.js#L63) which has been updated to node-agentkeepalive@2.0.2