### PR TITLE
increase socket pool to 128

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ function S3(uri, callback) {
 
 S3.agent = new AgentKeepAlive.HttpsAgent({
     keepAlive: true,
-    maxSockets: 16,
+    maxSockets: 128,
     keepAliveTimeout: 60000
 });
 


### PR DESCRIPTION
The socket pool on the agentkeepalive agent was 128 in 1.4.x (by way of node-tilejson https://github.com/mapbox/node-tilejson/blob/v0.13.0/lib/tilejson.js#L8-L15).  It was changed to 16 in 2.0.0.  This changes it back to 128.