### PR TITLE
Include x-amz-request-id, x-amz-id-2 in 5xx errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,8 +84,21 @@ S3.agent = new AgentKeepAlive.HttpsAgent({
     keepAliveTimeout: 60000
 });
 
-function managedError(err, grid) {
+function managedError(err, context, grid) {
     if (!err) return false;
+
+    // If call context was passed from AWS SDK we may have access to the
+    // httpResponse headers to attach an x-amz-request-id. Attempt to do so.
+    if (context &&
+        context.httpResponse &&
+        context.httpResponse.headers) {
+        if (context.httpResponse.headers['x-amz-request-id']) {
+            err.amzRequestId = context.httpResponse.headers['x-amz-request-id'];
+        }
+        if (context.httpResponse.headers['x-amz-id-2']) {
+            err.amzId2 = context.httpResponse.headers['x-amz-id-2'];
+        }
+    }
 
     var error, msg;
     if (err.name === 'TimeoutError') {
@@ -120,12 +133,23 @@ function managedError(err, grid) {
     }
 
     if (!error) return false;
+
+    if (err.amzRequestId) {
+        error.message = '[x-amz-request-id:' + err.amzRequestId + '] ' + error.message;
+        error.amzRequestId = err.amzRequestId;
+    }
+
+    if (err.amzId2) {
+        error.message = '[x-amz-id-2:' + err.amzId2 + '] ' + error.message;
+        error.amzId2 = err.amzId2;
+    }
+
     Error.captureStackTrace(error, arguments.callee);
     return error;
 }
 
 function onRetry(res) {
-    if (managedError(res.error)) res.error.retryable = managedError(res.error).retryable;
+    if (managedError(res.error, res)) res.error.retryable = managedError(res.error, res).retryable;
 }
 
 S3.registerProtocols = function(tilelive) {
@@ -192,7 +216,7 @@ S3.prototype._loadTile = function(z, x, y, callback) {
 
     var url = this._prepareURL(this.data.tiles[0], z, x, y);
     this.get(url, function(err, data, headers) {
-        if (err) return callback(managedError(err) || err);
+        if (err) return callback(managedError(err, this) || err);
 
         var modified = headers['last-modified'] ? new Date(headers['last-modified']) : new Date();
         var responseHeaders = tiletype.headers(data);
@@ -247,7 +271,7 @@ S3.prototype.getGrid = function(z, x, y, callback) {
     var url = this._prepareURL(this.data.grids[0], z, x, y);
 
     this.get(url, function(err, grid, headers) {
-        if (err) return callback(managedError(err, true) || err);
+        if (err) return callback(managedError(err, this, true) || err);
 
         var modified = headers['last-modified'] ? new Date(headers['last-modified']) : new Date();
         var responseHeaders = {
@@ -384,7 +408,7 @@ S3.prototype.put = function(key, data, headers, callback) {
         var attempts = 5;
         stats.get++;
         var req = s3.getObject(params, function(err, response) {
-            err = managedError(err) || err;
+            err = managedError(err, this) || err;
             if (err && (err.statusCode === 404 || err.statusCode === 403)) return put();
             if (err) return callback(err);
 
@@ -414,7 +438,7 @@ S3.prototype.put = function(key, data, headers, callback) {
         if (headers['Content-Encoding']) params.ContentEncoding = headers['Content-Encoding'];
 
         s3.putObject(params, function(err, response) {
-            if (err) return callback(managedError(err) || err);
+            if (err) return callback(managedError(err, this) || err);
 
             stats.put++;
             stats.txout += data.length;
@@ -506,7 +530,7 @@ S3.prototype.getGeocoderData = function(type, shard, callback) {
         var uri = prepareURI(this.data.geocoder_data, shard);
         uri.pathname = path.join(uri.pathname, type + '/' + shard + extname);
         this.get(url.format(uri), function(err, zdata) {
-            if (err) return callback(managedError(err) || err);
+            if (err) return callback(managedError(err, this) || err);
             zlib.inflate(zdata, function(err, data) {
                 if (err) return callback(err);
                 callback(null, data);

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,12 +134,12 @@ function managedError(err, context, grid) {
 
     if (!error) return false;
 
-    if (err.amzRequestId) {
+    if (error.statusCode >= 500 && err.amzRequestId) {
         error.message = '[x-amz-request-id:' + err.amzRequestId + '] ' + error.message;
         error.amzRequestId = err.amzRequestId;
     }
 
-    if (err.amzId2) {
+    if (error.statusCode >= 500 && err.amzId2) {
         error.message = '[x-amz-id-2:' + err.amzId2 + '] ' + error.message;
         error.amzId2 = err.amzId2;
     }

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -31,6 +31,8 @@ var mock = http.createServer(function (req, res) {
         length: /^\/lengthget(\/\d){3}.png$/
     };
 
+    res.setHeader('x-amz-request-id', '0000000000000000');
+    res.setHeader('x-amz-id-2', '01234567');
 
     if (routes.slow.test(req.url)) {
         return setTimeout(function() {
@@ -355,7 +357,7 @@ test('getTile retry internal error', function(assert) {
         source.startWriting(function(err) {
             if (err) return done(err);
             source.getTile(3, 6, 5, function(err) {
-                assert.equal(err.message, 'unknown error', 'expected message');
+                assert.equal(err.message, '[x-amz-id-2:01234567] [x-amz-request-id:0000000000000000] unknown error', 'expected message');
                 assert.equal(err.statusCode, 500, 'expected statusCode');
                 assert.equal(attempts, 5, 'retried 4 times');
                 assert.end();
@@ -375,7 +377,7 @@ test('putTile fails on GET internal error', function(assert) {
         source.startWriting(function(err) {
             if (err) return done(err);
             source.putTile(3, 6, 5, png, function(err) {
-                assert.equal(err.message, 'unknown error', 'expected message');
+                assert.equal(err.message, '[x-amz-id-2:01234567] [x-amz-request-id:0000000000000000] unknown error', 'expected message');
                 assert.equal(err.statusCode, 500, 'expected statusCode');
                 assert.equal(attempts, 5, 'retried GET 4 times, no put attempt');
                 assert.end();
@@ -395,7 +397,7 @@ test('putTile retry on PUT internal error', function(assert) {
         source.startWriting(function(err) {
             if (err) return done(err);
             source.putTile(3, 6, 5, png, function(err) {
-                assert.equal(err.message, 'unknown error', 'expected message');
+                assert.equal(err.message, '[x-amz-id-2:01234567] [x-amz-request-id:0000000000000000] unknown error', 'expected message');
                 assert.equal(err.statusCode, 500, 'expected statusCode');
                 assert.equal(attempts, 6, 'retried PUT 4 times');
                 assert.end();
@@ -414,7 +416,7 @@ test('putTile no retry on PUT http error (no body)', function(assert) {
         source.startWriting(function(err) {
             if (err) return done(err);
             source.putTile(3, 6, 5, png, function(err) {
-                assert.equal(err.message, '503 Unknown');
+                assert.equal(err.message, '[x-amz-id-2:01234567] [x-amz-request-id:0000000000000000] 503 Unknown');
                 assert.equal(err.statusCode, 503, 'expected statusCode');
                 assert.equal(attempts, 6, 'retried PUT 4 times');
                 assert.end();
@@ -434,7 +436,7 @@ test('getTile error with no body', function(assert) {
         source.startWriting(function(err) {
             if (err) return done(err);
             source.getTile(3, 6, 5, function(err) {
-                assert.equal(err.message, '503 Unknown', 'expected message');
+                assert.equal(err.message, '[x-amz-id-2:01234567] [x-amz-request-id:0000000000000000] 503 Unknown', 'expected message');
                 assert.equal(err.statusCode, 503, 'expected statusCode');
                 assert.equal(attempts, 5, 'retried 4 times');
                 assert.end();
@@ -455,7 +457,7 @@ test('getTile retry on content-length mismatch', function(assert) {
             if (err) return done(err);
             source.getTile(3, 6, 5, function(err) {
                 assert.equal(err.code, 'TruncatedResponseError', 'expected error code');
-                assert.equal(err.message, 'Content-Length does not match response body length', 'expected message');
+                assert.equal(err.message, '[x-amz-id-2:01234567] [x-amz-request-id:0000000000000000] Content-Length does not match response body length', 'expected message');
                 assert.equal(err.statusCode, 500, 'expected statusCode');
                 assert.equal(attempts, 5, 'retried 4 times');
                 assert.end();


### PR DESCRIPTION
- Adds `amzRequestId`,  `amzId2` properties to any 5xx error objects where the http response context is available
- Prepends the `err.message` with `[x-amz-request-id: {id}]` and `[x-amz-id-2: {id}]` for transparent logging/display of these values

Would be interesting to try to at least get attachment of these properties to the `err` object upstream in `aws-sdk-js`.

cc @rclark 