### PR TITLE
Expires (and friends)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,11 @@ function S3(uri, callback) {
 
         var query = qs.parse(uri.query);
         uri.acl = query.acl || 'public-read';
+        if (query.expires && /^[0-9]+$/.test(query.expires)) {
+            uri.expires = parseInt(query.expires, 10);
+        } else if (query.expires) {
+            uri.expires = query.expires;
+        }
     }
 
     var source = this;
@@ -69,6 +74,7 @@ function S3(uri, callback) {
         if (source.data.prepare) source._prepare = Function('url,z,x,y', source.data.prepare);
 
         source.acl = uri.acl || 'public-read';
+        source.expires = uri.expires && !isNaN(+new Date(uri.expires)) ? new Date(uri.expires) : undefined;
         source.client = uri.client || new AWS.S3({
             maxRetries: 4,
             httpOptions: {
@@ -200,7 +206,8 @@ S3.prototype.get = function(url, callback) {
             'content-length': response.ContentLength,
             'etag': response.ETag,
             'last-modified': response.LastModified,
-            'cache-control': response.CacheControl
+            'cache-control': response.CacheControl,
+            'expires': S3.futurize(response.Expires)
         });
     })
     .on('retry', onRetry)
@@ -230,7 +237,9 @@ S3.prototype._loadTile = function(z, x, y, callback) {
         if (headers['cache-control']) {
             responseHeaders['Cache-Control'] = headers['cache-control'];
         }
-
+        if (headers['expires']) {
+            responseHeaders['Expires'] = headers['expires'];
+        }
         callback(null, data, responseHeaders);
     });
 };
@@ -395,6 +404,7 @@ S3.prototype.putTile = function(z, x, y, data, callback) {
     headers['x-amz-acl'] = this.acl;
     headers['Connection'] = 'keep-alive';
     headers['Content-Length'] = data.length;
+    if (this.expires) headers['Expires'] = this.expires;
     this.put(key, data, headers, callback);
 };
 
@@ -440,6 +450,7 @@ S3.prototype.put = function(key, data, headers, callback) {
         params.Body = data;
         params.ACL = headers['x-amz-acl'];
         params.ContentType = headers['Content-Type'];
+        if (headers['Expires']) params.Expires = headers['Expires'];
         if (headers['Content-Encoding']) params.ContentEncoding = headers['Content-Encoding'];
 
         s3.putObject(params, function(err, response) {
@@ -612,3 +623,19 @@ S3.prototype.getIndexableDocs = function(pointer, callback) {
         callback(null, docs, pointer);
     });
 };
+
+// Ensure an Expires header is set in the future at the nearest +60s
+// interval from the original Expires time.
+S3.futurize = function(expires) {
+    if (!expires) return undefined;
+    now = new Date(Math.ceil(+new Date/1e3)*1e3);
+    expires = new Date(expires);
+    if (expires > now) {
+        return expires.toUTCString();
+    } else {
+        // Add N minutes
+        var extraMinutes = Math.ceil((now - Number(expires))/60e3) * 60e3;
+        return (new Date(Number(expires) + extraMinutes)).toUTCString();
+    }
+};
+

--- a/test/futurify.test.js
+++ b/test/futurify.test.js
@@ -1,0 +1,45 @@
+var tape = require('tape');
+var S3 = require('../lib/index.js');
+
+tape('futurize', function(assert) {
+    assert.deepEqual(S3.futurize(0), undefined, 'no-op on 0');
+    assert.deepEqual(S3.futurize(null), undefined, 'no-op on null');
+    assert.deepEqual(S3.futurize(false), undefined, 'no-op on false');
+    assert.deepEqual(S3.futurize(undefined), undefined, 'no-op on undefined');
+
+    var expires, now;
+
+    expires = new Date(+new Date + 1e3);
+    assert.deepEqual(S3.futurize(expires), expires.toUTCString(), 'passthrough on future expires');
+
+    expires = new Date(+new Date - 10e3);
+    assert.deepEqual(S3.futurize(expires), (new Date(Number(expires) + 60e3)).toUTCString(), 'bumps past expires up to nearest +60s time in the future');
+
+    expires = new Date(+new Date - 70e3);
+    assert.deepEqual(S3.futurize(expires), (new Date(Number(expires) + 120e3)).toUTCString(), 'bumps past expires up to nearest +60s time in the future');
+
+    expires = new Date(+new Date - 90e3);
+    assert.deepEqual(S3.futurize(expires), (new Date(Number(expires) + 120e3)).toUTCString(), 'bumps past expires up to nearest +60s time in the future');
+
+    // fuzz test
+    var pass = true;
+    for (var i = 0; i < 10000; i++) {
+        expires = new Date(+new Date - Math.floor(Math.random() * 864e5));
+        now = new Date();
+        if (expires > now) {
+            assert.fail('expires not in the past');
+            pass = false;
+        }
+        if (new Date(S3.futurize(expires)) <= now) {
+            assert.fail('futurize puts expires in the future: ' + new Date(S3.futurize(expires)) + ' vs ' + new Date(now));
+            pass = false;
+        }
+        if (new Date(S3.futurize(expires)) > (+now + 60e3)) {
+            assert.fail('but <= 60s into the future');
+            pass = false;
+        }
+    }
+    assert.ok(pass, 'fuzz x10000');
+
+    assert.end();
+});


### PR DESCRIPTION
- Adds support for writing tiles to S3 with Expires set
- Includes Expires header on getTile if present on S3 object. Enforces an expires time in the future and pushes to the nearest 60s interval in the future after the original expire time.