### PR TITLE
Expose timeout value to exports for custom values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ function S3(uri, callback) {
         source.client = uri.client || new AWS.S3({
             maxRetries: 4,
             httpOptions: {
-                timeout: 5000,
+                timeout: S3.timeout,
                 agent: S3.agent
             }
         });
@@ -87,6 +87,8 @@ function S3(uri, callback) {
         callback(err, source);
     }
 };
+
+S3.timeout = 5000;
 
 S3.agent = new AgentKeepAlive.HttpsAgent({
     keepAlive: true,


### PR DESCRIPTION
Exposes `timeout` value to `module.exports` so it can be adjusted for use-case specific values.