### PR TITLE
ACL private by default.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ function S3(uri, callback) {
         };
 
         var query = typeof uri.query === 'string' ? qs.parse(uri.query) : (uri.query || {});
-        uri.acl = query.acl || 'public-read';
+        uri.acl = query.acl || 'private';
         uri.sse = query.sse;
         uri.sseKmsId = query.sseKmsId;
         if (query.expires && /^[0-9]+$/.test(query.expires)) {

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -32,8 +32,7 @@ tape('setup', function(assert) {
 
 tape('setup', function(assert) {
     new S3({
-        pathname: fixtures + '/vector.s3',
-        acl: 'private'
+        pathname: fixtures + '/vector.s3'
     }, function(err, source) {
         assert.ifError(err);
         vt = source;
@@ -43,7 +42,8 @@ tape('setup', function(assert) {
 
 tape('setup', function(assert) {
     new S3({
-        pathname: fixtures + '/notfound.s3'
+        pathname: fixtures + '/notfound.s3',
+        acl: 'public-read'
     }, function(err, source) {
         assert.ifError(err);
         nf = source;
@@ -71,15 +71,15 @@ tape('marks source as open', function(assert) {
 });
 
 tape('reads from uri.query', function(assert) {
-    new S3(url.parse('s3://mapbox/tilelive-s3/test/{z}/{x}/{y}.png?acl=private&sse=aws:kms&sseKmsId=foo', true), function(err, source) {
+    new S3(url.parse('s3://mapbox/tilelive-s3/test/{z}/{x}/{y}.png?acl=public-read&sse=aws:kms&sseKmsId=foo', true), function(err, source) {
         assert.ifError(err, 'success');
-        assert.equal(source.acl, 'private', 'sets source.acl = private');
+        assert.equal(source.acl, 'public-read', 'sets source.acl = public-read');
         assert.equal(source.sse, 'aws:kms', 'sets source.sse = aws:kms');
         assert.equal(source.sseKmsId, 'foo', 'sets source.sseKmsId = foo');
     });
-    new S3(url.parse('s3://mapbox/tilelive-s3/test/{z}/{x}/{y}.acl png?acl=private&sse=aws:kms'), function(err, source) {
+    new S3(url.parse('s3://mapbox/tilelive-s3/test/{z}/{x}/{y}.acl png?acl=public-read&sse=aws:kms'), function(err, source) {
         assert.ifError(err, 'success');
-        assert.equal(source.acl, 'private', 'sets source.acl = acl private');
+        assert.equal(source.acl, 'public-read', 'sets source.acl = public-read');
         assert.equal(source.sse, 'aws:kms', 'sets source.sse = aws:kms');
     });
     assert.end();
@@ -231,7 +231,7 @@ tape('setup', function(assert) {
 });
 
 tape('setup', function(assert) {
-    new S3('s3://mapbox/tilelive-s3/test-put/' + tmpid + '/{z}/{x}/{y}.png?sse=AES256', function(err, source) {
+    new S3('s3://mapbox/tilelive-s3/test-put/' + tmpid + '/{z}/{x}/{y}.png?acl=public-read&sse=AES256', function(err, source) {
         assert.ifError(err);
         s3 = source;
         assert.end();
@@ -239,7 +239,7 @@ tape('setup', function(assert) {
 });
 
 tape('setup', function(assert) {
-    new S3('s3://mapbox/tilelive-s3/test-put/' + tmpid + '/{z}/{x}/{y}.vector.pbf?acl=private', function(err, source) {
+    new S3('s3://mapbox/tilelive-s3/test-put/' + tmpid + '/{z}/{x}/{y}.vector.pbf', function(err, source) {
         assert.ifError(err);
         vt = source;
         assert.end();


### PR DESCRIPTION
Put objects to S3 with a `private` [S3 ACL](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) by default. This is a change is not backwards-compatible, but clients can retain old behavior by settings `acl=public-read`.