### PR TITLE
use setImmediate when available instead of deprecated nextTick

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,8 @@ var url = require('url');
 
 module.exports = S3;
 
+var immediate = global.setImmediate || process.nextTick;
+
 var defaultAgent = new AgentKeepAlive.HttpsAgent({
     keepAlive: true,
     maxSockets: 128,
@@ -337,7 +339,7 @@ S3.prototype.putTile = function(z, x, y, data, callback) {
     // Don't put solid tiles beyond fillzoom.
     if (data.key && data.key < 0 && this.data.fillzoom && z > this.data.fillzoom) {
         this._stats.noop++;
-        return process.nextTick(function() { callback(); });
+        return immediate(function() { callback(); });
     }
     var key = url.parse(this._prepareURL(this.data.tiles[0], z, x, y)).pathname.slice(1);
     var headers = tiletype.headers(data);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilelive-s3",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "dependencies": {
     "agentkeepalive": "^2.0.3",
     "aws-sdk": "^2.2.19",


### PR DESCRIPTION
encountered as an error message while debugging another project; seemed worth cleaning up to eliminate as a potential source of trouble.