### PR TITLE
Bring your own region

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ if (process.env.AWS_S3_ENDPOINT) {
     }
 }
 
-var S3Client = new AWS.S3({
+var defaultClientOpts = {
     s3ForcePathStyle: !!process.env.AWS_S3_ENDPOINT,
     endpoint: process.env.AWS_S3_ENDPOINT,
     maxRetries: 4,
@@ -43,7 +43,7 @@ var S3Client = new AWS.S3({
         timeout: 2000,
         agent: defaultAgent
     }
-});
+};
 
 utils.inherits(S3, Emitter);
 function S3(uri, callback) {
@@ -54,6 +54,11 @@ function S3(uri, callback) {
     this._cacheMasks = {};
     this._stats = { get: 0, put: 0, noop: 0, txin: 0, txout: 0 };
     this._prepare = function(url) { return url };
+
+    // passing a string URL with ?region=eu-west-1 will initialize the S3 client
+    // for the desired region
+    var region = qs.parse(uri.query).region
+    defaultClientOpts.region = region;
 
     // If a parsed uri of the form s3://[bucket]/[path template] is passed,
     // assume that tiles are implied (no grids), and generate a data
@@ -111,7 +116,7 @@ function S3(uri, callback) {
         source.sse = uri.sse;
         source.sseKmsId = uri.sseKmsId;
         source.expires = uri.expires && !isNaN(+new Date(uri.expires)) ? new Date(uri.expires) : undefined;
-        source.client = uri.client || S3Client;
+        source.client = uri.client || new AWS.S3(defaultClientOpts);
         if (uri.timeout) source.client.config.httpOptions.timeout = uri.timeout;
 
         source.open = true;

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -721,3 +721,15 @@ tape('expires cleanup', function(assert) {
 
 })();
 
+tape('accepts region', function(assert) {
+    assert.plan(2);
+    var S3client = AWS.S3;
+    AWS.S3 = function(params) {
+        assert.equal(params.region, 'eu-central-1', 'S3 client with proper region');
+    }
+
+    new S3('s3://mapbox/tilelive-s3?region=eu-central-1', function(err) {
+        assert.ifError(err, 'successfully created client');
+        AWS.S3 = S3client;
+    });
+});


### PR DESCRIPTION
By specifying the desired bucket region as a querystring arg in the S3 URI:

```
s3://my-german-bucket/tileset/{z}/{x}/{y}?region=eu-central-1
```