### PR TITLE
Accept region in pre-parsed uri

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ var defaultClientOpts = {
 
 utils.inherits(S3, Emitter);
 function S3(uri, callback) {
-    if (typeof uri === 'string') uri = url.parse(uri);
+    if (typeof uri === 'string') uri = url.parse(uri, true);
     this._uri = uri;
     this._cacheSolid;
     this._cacheNotFound;
@@ -57,8 +57,11 @@ function S3(uri, callback) {
 
     // passing a string URL with ?region=eu-west-1 will initialize the S3 client
     // for the desired region
-    var region = qs.parse(uri.query).region
-    defaultClientOpts.region = region;
+    if (uri.query) {
+        var region = typeof uri.query === 'string' ?
+            qs.parse(uri.query).region : uri.query.region;
+        defaultClientOpts.region = region;
+    }
 
     // If a parsed uri of the form s3://[bucket]/[path template] is passed,
     // assume that tiles are implied (no grids), and generate a data

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ var defaultClientOpts = {
 
 utils.inherits(S3, Emitter);
 function S3(uri, callback) {
-    if (typeof uri === 'string') uri = url.parse(uri, true);
+    if (typeof uri === 'string') uri = url.parse(uri);
     this._uri = uri;
     this._cacheSolid;
     this._cacheNotFound;

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -734,7 +734,7 @@ tape('accepts region', function(assert) {
     });
 });
 
-tape('accepts region in pre-parsed uri', function(assert) {
+tape('accepts region in pre-parsed uri (qs.parsed)', function(assert) {
     assert.plan(2);
     var S3client = AWS.S3;
     AWS.S3 = function(params) {
@@ -742,6 +742,19 @@ tape('accepts region in pre-parsed uri', function(assert) {
     }
 
     new S3(url.parse('s3://mapbox/tilelive-s3?region=eu-central-1', true), function(err) {
+        assert.ifError(err, 'successfully created client');
+        AWS.S3 = S3client;
+    });
+});
+
+tape('accepts region in pre-parsed uri (not qs.parsed)', function(assert) {
+    assert.plan(2);
+    var S3client = AWS.S3;
+    AWS.S3 = function(params) {
+        assert.equal(params.region, 'eu-central-1', 'S3 client with proper region');
+    }
+
+    new S3(url.parse('s3://mapbox/tilelive-s3?region=eu-central-1', false), function(err) {
         assert.ifError(err, 'successfully created client');
         AWS.S3 = S3client;
     });

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -733,3 +733,16 @@ tape('accepts region', function(assert) {
         AWS.S3 = S3client;
     });
 });
+
+tape('accepts region in pre-parsed uri', function(assert) {
+    assert.plan(2);
+    var S3client = AWS.S3;
+    AWS.S3 = function(params) {
+        assert.equal(params.region, 'eu-central-1', 'S3 client with proper region');
+    }
+
+    new S3(url.parse('s3://mapbox/tilelive-s3?region=eu-central-1', true), function(err) {
+        assert.ifError(err, 'successfully created client');
+        AWS.S3 = S3client;
+    });
+});


### PR DESCRIPTION
#84 allowed the caller to set a region via querystring. This expands that to allow caller to pass a pre-parsed URI where the querystring has or has not already been parsed.