### PR TITLE
Pull region name from http hostname instead of ?region quiery

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,10 +98,13 @@ function S3(uri, callback) {
             if (source.bucket && params.Bucket !== source.bucket) err = new Error('buckets for tiles and grids must match');
             source.bucket = params.Bucket;
 
-            var query = url.parse(source.data[key][0], true).query;
-            if (!query.region) return;
-            if (source.region && query.region !== source.region) err = new Error('buckets for tiles and grids must be in the same region');
-            source.region = query.region;
+            // Change all of this to be determined by the hostname
+            var match = source.data[key][0].match(/s3\.([\w-]+)\.amazonaws.com/);
+            if (match) {
+                var region = match[1];
+                if (source.region && source.region !== region) err = new Error('buckets for tiles and grids must be in the same region');
+                source.region = region;
+            }
         });
 
         source.client = uri.client || new AWS.S3({


### PR DESCRIPTION
This unlocks moving away from the `?region=<region>`-specific querystring for creating an S3 client with access to a specific region. Instead, just check if the hostname has the format:

```
s3.<region>.amazon.com
```

and if that's the case, use that region to initialize the S3 client.

cc/ @willwhite @rclark @zmully @yhahn 
