### PR TITLE
Implement strict mode that respects min/max zoom

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,10 @@ function S3(uri, callback) {
     }
 
     var source = this;
-    if (uri.data) { return setup(null, uri.data); }
+    if (uri.data) {
+      if (uri.strict && uri.strict === true) uri.data.strict = true;
+      return setup(null, uri.data);
+    }
     if (uri.pathname) return fs.readFile(uri.pathname, 'utf8', setup);
     callback(new Error('Invalid URI'));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,10 +82,7 @@ function S3(uri, callback) {
     }
 
     var source = this;
-    if (uri.data) {
-      if (uri.strict && uri.strict === true) uri.data.strict = true;
-      return setup(null, uri.data);
-    }
+    if (uri.data) { return setup(null, uri.data); }
     if (uri.pathname) return fs.readFile(uri.pathname, 'utf8', setup);
     callback(new Error('Invalid URI'));
 
@@ -126,6 +123,7 @@ function S3(uri, callback) {
         source.sseKmsId = uri.sseKmsId;
         source.expires = uri.expires && !isNaN(+new Date(uri.expires)) ? new Date(uri.expires) : undefined;
         if (uri.timeout) source.client.config.httpOptions.timeout = uri.timeout;
+        if (uri.strict && uri.strict === true) source.strict = true;
 
         source.open = true;
         source.emit('open', err, source);
@@ -269,7 +267,7 @@ S3.prototype.get = function(url, callback) {
 S3.prototype._loadTile = function(z, x, y, callback) {
     if (!this.data) return callback(new Error('Tilesource not loaded'));
     if (!this.data.tiles) return callback(new Error('No "tiles" key'));
-    if (this.data.strict) {
+    if (this.strict) {
       if (z < this.data.minzoom || z > this.data.maxzoom) return callback(new Error('Tile does not exist'));
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -266,6 +266,9 @@ S3.prototype.get = function(url, callback) {
 S3.prototype._loadTile = function(z, x, y, callback) {
     if (!this.data) return callback(new Error('Tilesource not loaded'));
     if (!this.data.tiles) return callback(new Error('No "tiles" key'));
+    if (this.data.strict) {
+      if (z < this.data.minzoom || z > this.data.maxzoom) return callback(new Error('Tile does not exist'));
+    }
 
     var url = this._prepareURL(this.data.tiles[0], z, x, y);
     this.get(url, function(err, data, headers) {

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -803,7 +803,8 @@ tape('strict mode', function(t) {
             return reqObj;
         }
         new S3({
-            data: { tiles: ['http://mapbox.s3.amazonaws.com/tilelive-s3/test/{z}/{x}/{y}.png'], minzoom: 1, maxzoom: 3, strict: true }
+            data: { tiles: ['http://mapbox.s3.amazonaws.com/tilelive-s3/test/{z}/{x}/{y}.png'], minzoom: 1, maxzoom: 3 },
+            strict: true
         }, function(err, source) {
             assert.ifError(err);
             s3 = source;

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -782,3 +782,68 @@ tape('accepts region in tilejson', function(assert) {
         AWS.S3 = S3client;
     });
 });
+
+tape('strict mode', function(t) {
+    var S3client = AWS.S3;
+    var s3;
+    var io = true;
+
+    t.test('setup', function(assert) {
+        AWS.S3 = function(params) {}
+        AWS.S3.prototype.getObject = function(params, callback) {
+            if (io) {
+              assert.deepEqual(params, { Bucket: 'mapbox', Key: 'tilelive-s3/test/2/2/2.png' });
+              callback(null, { Body: {} });
+            } else {
+              assert.ok(io);
+            }
+            var reqObj = {
+              on: function() { return reqObj; }
+            }
+            return reqObj;
+        }
+        new S3({
+            data: { tiles: ['http://mapbox.s3.amazonaws.com/tilelive-s3/test/{z}/{x}/{y}.png'], minzoom: 1, maxzoom: 3, strict: true }
+        }, function(err, source) {
+            assert.ifError(err);
+            s3 = source;
+            assert.end();
+        });
+    });
+
+    t.test('getTile - within min/max zoom', function(assert) {
+        io = true;
+        s3.getTile(2, 2, 2, function(err, tile, headers) {
+            assert.ifError(err);
+            assert.ok(tile);
+            assert.end();
+        });
+    });
+
+    t.test('getTile - below min zoom', function(assert) {
+        io = false;
+        s3.getTile(0, 0, 0, function(err, tile, headers) {
+            assert.ok(err);
+            assert.equal(err.message, 'Tile does not exist');
+            assert.notOk(tile);
+            assert.end();
+        });
+    });
+
+    t.test('getTile - above max zoom', function(assert) {
+        io = false;
+        s3.getTile(5, 5, 5, function(err, tile, headers) {
+            assert.ok(err);
+            assert.equal(err.message, 'Tile does not exist');
+            assert.notOk(tile);
+            assert.end();
+        });
+    });
+
+    t.test('cleanup', function(assert) {
+        AWS.S3 = S3client;
+        assert.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Optional `strict` property will short-circuit requests to S3 if a tile is below a minzoom or above a maxzoom. This cuts down on actually doing io for requests that are known 404s.

cc @yhahn 