### PR TITLE
Require at least aws-sdk >= 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.5.0",
   "dependencies": {
     "agentkeepalive": "^2.0.3",
-    "aws-sdk": "^2.2.19",
+    "aws-sdk": "^2.6.0",
     "s3urls": "^1.4.0",
     "@mapbox/tiletype": "^0.3.0"
   },


### PR DESCRIPTION
This ensures at least aws-sdk >= 2.6.0 is used. The case where this would not happen is if a downstream module pins `aws-sdk` to an earlier version. E.g. if a downstream module pinned at `2.5.0` in their `package.json`, then tilelive-s3 would use that version.

Let's enforce at least 2.6.0 to ensure that the dreaded `Missing credentials in config` fades into the past when using tilelive-s3 with ECS services. 2.6.0 include retry with exponential backoff, by default, from aws/aws-sdk-js#1114 to fix aws/aws-sdk-js#692 (https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#260).


/cc @rclark @mapsam