### PR TITLE
Add put events 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,9 @@ function S3(uri, callback) {
         uri.acl = query.acl || 'private';
         uri.sse = query.sse;
         uri.sseKmsId = query.sseKmsId;
+
+        this._eventsEnabled = (query.events && query.events === 'true') || false;
+
         if (query.timeout && /^[0-9]+$/.test(query.timeout)) {
             uri.timeout = parseInt(query.timeout);
         }
@@ -361,6 +364,7 @@ S3.prototype.putTile = function(z, x, y, data, callback) {
         this._stats.noop++;
         return immediate(function() { callback(); });
     }
+    var source = this;
     var key = url.parse(this._prepareURL(this.data.tiles[0], z, x, y)).pathname.slice(1);
     var headers = tiletype.headers(data);
     headers['x-amz-acl'] = this.acl;
@@ -369,7 +373,10 @@ S3.prototype.putTile = function(z, x, y, data, callback) {
     headers['Connection'] = 'keep-alive';
     headers['Content-Length'] = data.length;
     if (this.expires) headers['Expires'] = this.expires;
-    this.put(key, data, headers, callback);
+    this.put(key, data, headers, function (err) {
+        if (!err && source._eventsEnabled) source.emit('putTile', z, x, y, data.length);
+        callback(err);
+    });
 };
 
 // Generic PUT method for S3 keys. Handles conditional GETs and


### PR DESCRIPTION
Useful for clients to build custom put metrics or otherwise respond to the fact a tile is now on S3.

Because put events on every single tile put could be a performance ding, I've but it behind an `?events=true` uri flag