### PR TITLE
Use AWS signature V4 in order to work with newer endpoints such as Frankfurt

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,8 @@ function S3(uri, callback) {
             httpOptions: {
                 timeout: 2000,
                 agent: defaultAgent
-            }
+            },
+            signatureVersion: 'v4'
         });
 
         if (source.data.mtime) source.mtime = new Date(source.data.mtime);


### PR DESCRIPTION
If you leave the signature version off, it defaults to a version which doesn't work at all with newer AWS endpoints such as Frankfurt.