### PR TITLE
Add connectTimeout of 100 ms

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,6 +114,7 @@ function S3(uri, callback) {
             maxRetries: 4,
             httpOptions: {
                 timeout: 2000,
+                connectTimeout: 100,
                 agent: defaultAgent
             }
         });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.6.0",
   "dependencies": {
     "agentkeepalive": "^2.0.3",
-    "aws-sdk": "^2.6.0",
+    "aws-sdk": "^2.58.0",
     "s3urls": "^1.4.0",
     "@mapbox/tiletype": "^0.3.0"
   },


### PR DESCRIPTION
Adds connectTimeout option to `httpOptions` of the default S3 aws-sdk client.

**Next actions:**

- [ ] Add tests
- [ ] Benchmark to see if anything changes
- [ ] Stage
- [ ] Canary
- [ ] Merge
- [ ] Release
- [ ] Deploy fully to prod

cc/ @springmeyer @rclark @emilymcafee @yhahn 