### PR TITLE
Let s3ForcePathStyle inherit from global config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ function S3(uri, callback) {
         });
 
         source.client = uri.client || new AWS.S3({
-            s3ForcePathStyle: !!process.env.AWS_S3_ENDPOINT,
+            s3ForcePathStyle: !!process.env.AWS_S3_ENDPOINT || AWS.config.s3ForcePathStyle,
             region: source.region,
             endpoint: process.env.AWS_S3_ENDPOINT,
             maxRetries: 4,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,38 @@
+var tape = require('tape');
+var path = require('path');
+var fs = require('fs');
+var S3 = require('..');
+var crypto = require('crypto');
+var AWS = require('aws-sdk');
+var url = require('url');
+
+tape('configure s3 client', function(assert) {
+    delete process.env.AWS_S3_ENDPOINT;
+    delete AWS.config.s3ForcePathStyle;
+    new S3(url.parse('s3://mapbox/tilelive-s3/test/{z}/{x}/{y}.png'), function(err, source) {
+        assert.ifError(err);
+        assert.deepEqual(source.client.config.s3ForcePathStyle, false);
+        assert.end();
+    });
+});
+
+tape('configure s3 client (global config)', function(assert) {
+    delete process.env.AWS_S3_ENDPOINT;
+    AWS.config.s3ForcePathStyle = true;
+    new S3(url.parse('s3://mapbox/tilelive-s3/test/{z}/{x}/{y}.png'), function(err, source) {
+        assert.ifError(err);
+        assert.deepEqual(source.client.config.s3ForcePathStyle, true, 'respects global config');
+        assert.end();
+    });
+});
+
+tape('configure s3 client (custom endpoint)', function(assert) {
+    process.env.AWS_S3_ENDPOINT = 'http://localhost';
+    AWS.config.s3ForcePathStyle = false;
+    new S3(url.parse('s3://mapbox/tilelive-s3/test/{z}/{x}/{y}.png'), function(err, source) {
+        assert.ifError(err);
+        assert.deepEqual(source.client.config.s3ForcePathStyle, true, 'custom endpoint overrides global config');
+        assert.end();
+    });
+});
+


### PR DESCRIPTION
This adjusts the behavior of the s3 client created for `tilelive-s3` to fall back to the global `AWS.config.s3ForcePathStyle` value rather than always forcing a `false` value.

cc @ian29 @rmrice 